### PR TITLE
RPM support: fixed broken build due to use of headers from kernel

### DIFF
--- a/control/ipmitool.spec.in
+++ b/control/ipmitool.spec.in
@@ -34,7 +34,7 @@ fi
 %setup
 
 %build
-./configure --with-kerneldir \
+./configure \
 	--with-rpm-distro=@DISTRO@ \
 	--prefix=%{_prefix} \
 	--bindir=%{_bindir} \


### PR DESCRIPTION
When building an RPM, --with-kerneldir is passed to ./configure. This adds
the include path /lib/modules/<kversion>/build/include that may break the
build but is not present when building with "make" so useless.
For instance while building ipmi_sel.c with kernel 5.3.7-301.fc31.x86_64 :
/lib/modules/5.3.7-301.fc31.x86_64/build/include/linux/stddef.h:11:2: error:
expected identifier before numeric constant
   11 |  false = 0,
      |  ^~~~~

Signed-off-by: Gilles Buloz <gilles.buloz@kontron.com>